### PR TITLE
Added reference to Xray Vision to use instead of ExecutionWorld.MAIN

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -26,6 +26,7 @@ Values of this type are strings. Possible values are:
 
   > **Warning:** Due to the lack of isolation, the web page can detect the executed code and interfere with it.
   > Do not use the `MAIN` world unless it is acceptable for web pages to read, access, or modify the logic or data that flows through the executed code.
+  > `MAIN` is not supported in Firefox. Instead Firefox uses "Xray Vision" to achieve similar goals. See [Share objects with page scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts) for details.
 
 ## Browser compatibility
 


### PR DESCRIPTION
### Description

Added a link to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts as the `MAIN` ExecutionWorld is not supported by Firefox and the described Xray Vision in the linked article seems to be the preferred approach.

### Motivation

I stumbled across this very problem and wanted to share the solution with other developers.

### Additional details

None.

### Related issues and pull requests

None afaik